### PR TITLE
updated lernstick-sonic-pi

### DIFF
--- a/lernstick-sonic-pi/debian/changelog
+++ b/lernstick-sonic-pi/debian/changelog
@@ -1,3 +1,9 @@
+lernstick-sonic-pi (3) lernstick-9; urgency=medium
+
+  * changed the sonic-pi.lernstick to work with pulseaudio over a loop back interface
+
+ -- Thore Sommer <mail@thson.de>  Wed, 12 Jul 2017 20:00:00 +0200
+
 lernstick-sonic-pi (2) lernstick-9; urgency=medium
 
   * added wrapper script to suspend pulseaudio and start jackd automatically

--- a/lernstick-sonic-pi/usr/bin/sonic-pi.lernstick
+++ b/lernstick-sonic-pi/usr/bin/sonic-pi.lernstick
@@ -1,6 +1,9 @@
 #!/bin/sh
 
-pasuspender -- jackd -d alsa &
-sleep 1
+sudo modprobe snd-aloop index=10 pcm_substreams=1 || true
+jackd -d alsa -d hw:10 &
+sleep 3
+arecord -D plughw:10,1 -r 48000 -f FLOAT_LE -c 2  | aplay - &
 sonic-pi
 killall -9 jackd
+killall -9 arecord


### PR DESCRIPTION
This updates our Sonic Pi script to work with pulseaudio without suspending it.
The old solution has lower latency but only works in your default alsa device is your soundcard which is not always the case.
This solution creates an alsa loop back interface with the card id 10 and starts jackd with this loop back interface. To get audio in pulseaudio it streams the loop back interface into aplay.

See: https://github.com/samaaron/sonic-pi/issues/1109#issuecomment-314847309