### PR TITLE
don't show Nautilus in Cinnamon

### DIFF
--- a/lernstick-nautilus/debian/changelog
+++ b/lernstick-nautilus/debian/changelog
@@ -1,3 +1,9 @@
+lernstick-nautilus (3.1) lernstick-9; urgency=medium
+
+  * don't show nautilus in Cinnamon
+
+ -- Thore Sommer  <mail@thson.de>  Fri, 22 Sep 2017 07:00:00 +0200
+
 lernstick-nautilus (3) lernstick-9; urgency=medium
 
   * synced with Debian 9

--- a/lernstick-nautilus/usr/share/applications/org.gnome.Nautilus.desktop
+++ b/lernstick-nautilus/usr/share/applications/org.gnome.Nautilus.desktop
@@ -222,7 +222,8 @@ Keywords[zh_HK]=folder;manager;explore;disk;filesystem;資料夾;管理程式;�
 Keywords[zh_TW]=folder;manager;explore;disk;filesystem;資料夾;管理員;磁碟;檔案系統;
 Keywords=folder;manager;explore;disk;filesystem;
 Exec=nautilus --new-window %U
-OnlyShowIn=GNOME;
+# OnlyShowIn=GNOME doesn't work with Cinnamon
+NotShowIn=KDE;X-Cinnamon;MATE;LXDE;XFCE;X-Enlightenment;
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon[ar]=org.gnome.Nautilus
 Icon[bg]=org.gnome.Nautilus
@@ -327,4 +328,5 @@ Name[zh_CN]=新建窗口
 Name[zh_TW]=新增視窗
 Name=New Window
 Exec=nautilus --new-window
-OnlyShowIn=GNOME;
+# OnlyShowIn=GNOME doesn't work with Cinnamon
+NotShowIn=KDE;X-Cinnamon;MATE;LXDE;XFCE;X-Enlightenment;


### PR DESCRIPTION
Currently Cinnamon Shows up as Gnome, so we cannot use `OnlyShowIn=GNOME`